### PR TITLE
Enable link-time optimization when building Rust library for production

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
 # Update PATH for cargo
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
+    RUSTFLAGS="-C codegen-units=1" \
+    CARGO_PROFILE_RELEASE_LTO=fat \
     PATH=/usr/local/cargo/bin:$PATH
 
 # Install Rust toolchain, see https://rust-lang.github.io/rustup/installation/other.html

--- a/publish_windows.py
+++ b/publish_windows.py
@@ -24,6 +24,13 @@ if os.path.exists(zip_filename_debug):
 pathlib.Path(dst_dir).mkdir(parents=True, exist_ok=True)
 pathlib.Path(dst_dir_debug).mkdir(parents=True, exist_ok=True)
 
+# Build GDNative library with production optimizations
+subprocess.run(
+    ["cargo", "build", "--release"],
+    cwd="rust",
+    env={"RUSTFLAGS": "-C codegen-units=1", "CARGO_PROFILE_RELEASE_LTO": "fat"}
+)
+
 # Copy all dlls
 src_dir = "godot"
 for dll in glob.iglob(os.path.join(src_dir, "*.dll")):


### PR DESCRIPTION
This decreases the compiled library size and improves performance.

`codegen-units` is also set to 1 to further optimize the compiled library.

There's more advice here: https://likebike.com/posts/How_To_Write_Fast_Rust_Code.html

**Note:** I haven't tried to run the Godot project as a whole with these changes. It's likely that it will work as-is, but I recommend cloning [this branch](https://github.com/Calinou/bitmapflow/tree/rust-release-enable-lto) locally to test before merging.

## Preview

*Linux x86_64 (rustc nightly from 2021-03-26). Both libraries had their debug symbols removed by running `strip` on them.*

### Before (LTO disabled, `codegen-units = 16`)

```
2,672,984 target/release/libbitmapflow_rust.so
```

### After (LTO enabled, `codegen-units = 16`)

```
2,132,240 target/release/libbitmapflow_rust.so
```

### After (LTO enabled, `codegen-units = 1`) – this PR

```
2,066,704 target/release/libbitmapflow_rust.so
```